### PR TITLE
Fix cover page styling, remove IS stage

### DIFF
--- a/index-zh.html
+++ b/index-zh.html
@@ -2,9 +2,9 @@
 <!DOCTYPE html SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns:epub="http://www.idpf.org/2007/ops">
   <head>
-    
+
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    
+
     <link rel="stylesheet" type="text/css" href="style.css">
 
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
@@ -27,15 +27,15 @@
     <div class="document-stage-band" id="working-draft-band">
         <p class="document-stage">Working Draft</p>
     </div>
-    
+
     <div class="document-type-band" id="standard-band">
         <p class="document-type">Calconnect Standard</p>
     </div>
-      
-        
-    
+
+
+
       <div id='toggle'> <span>•</span> </div>
-    
+
       <header>
 <div class="WordSection1">
 
@@ -48,7 +48,7 @@
   </div>
 
 <div class="coverpage-logo">
-    
+
     <div class="coverpage-logo-gb-img">
       <img width='113' height='56' src='img/gb-standard-gm.gif' alt='GM'>
     </div>
@@ -81,11 +81,13 @@
         </div>
 </div>
 
-    
+
 <div class="coverpage-footer">
 
   <div class="coverpage-stage-block">
-    <span class="stage">IS Stage</span>
+    <!-- do not show at completed stage
+      <span class="stage">IS Stage</span>
+    -->
   </div>
 
   <div class="coverpage-dates">
@@ -96,7 +98,7 @@
   <div class="coverpage_footer">
     国家密码管理局
   </div>
-  
+
 </div>
 
 </div>
@@ -107,7 +109,7 @@
 <nav>
     <h1 id="content">目录</h1>
     <div id="toc"></div>
-  
+
 </nav>
 
 
@@ -167,13 +169,13 @@
       </div>
       <div id="terms"><h1 id="d083e843-f20f-4a01-b8b9-9e5e1b96f9cf">3.&#xA0; &#x672F;&#x8BED;&#x548C;&#x5B9A;&#x4E49;</h1><p>&#x4E0B;&#x5217;&#x672F;&#x8BED;&#x548C;&#x5B9A;&#x4E49;&#x9002;&#x7528;&#x4E8E;&#x672C;&#x6587;&#x4EF6;&#x3002;</p>
 <p id="_6dcc21ee-9e96-4607-a8ed-c216828b2888">&#x4E0B;&#x5217;&#x672F;&#x8BED;&#x548C;&#x5B9A;&#x4E49;&#x9002;&#x7528;&#x4E8E;&#x672C;&#x6587;&#x4EF6;&#x3002;</p><p class="TermNum" id="_string_language_zh_string_string_language_en_algorithm_identifier_string">3.1</p>
-  <p class="Terms">&#x7B97;&#x6CD5;&#x6807;&#x8BC6; algorithm identifier</p> 
+  <p class="Terms">&#x7B97;&#x6CD5;&#x6807;&#x8BC6; algorithm identifier</p>
   <p id="_631032ae-0ba9-4d5f-8b16-b90825d5c140">&#x7528;&#x4E8E;&#x6807;&#x660E;&#x7B97;&#x6CD5;&#x673A;&#x5236;&#x7684;&#x6570;&#x5B57;&#x5316;&#x4FE1;&#x606F;</p>
 <p class="TermNum" id="_string_language_zh_sm2_string_string_language_en_sm2_algorithm_string">3.2</p>
-  <p class="Terms">SM2&#x5BC6;&#x7801;&#x7B97;&#x6CD5; SM2 algorithm</p> 
+  <p class="Terms">SM2&#x5BC6;&#x7801;&#x7B97;&#x6CD5; SM2 algorithm</p>
   <p id="_98728d19-cb19-49f3-8230-cefab0ee81aa">&#x4E00;&#x79CD;&#x692D;&#x5706;&#x66F2;&#x7EBF;&#x5BC6;&#x7801;&#x7B97;&#x6CD5;&#xFF0C;&#x5BC6;&#x94A5;&#x957F;&#x5EA6;&#x4E3A;256&#x6BD4;&#x7279;&#x3002;</p>
 <p class="TermNum" id="_string_language_zh_sm3_string_string_language_en_sm3_algorithm_string">3.3</p>
-  <p class="Terms">SM3&#x7B97;&#x6CD5; SM3 algorithm</p> 
+  <p class="Terms">SM3&#x7B97;&#x6CD5; SM3 algorithm</p>
   <p id="_5c69984d-6f70-40c6-b411-08119eca9fc5">&#x4E00;&#x79CD;&#x6742;&#x51D1;&#x7B97;&#x6CD5;&#xFF0C;&#x8F93;&#x51FA;&#x957F;&#x5EA6;&#x4E3A;256&#x6BD4;&#x7279;&#x3002;</p>
 </div>
       <div id="introduction">
@@ -636,7 +638,7 @@ SM2-3&#x692D;&#x5706;&#x66F2;&#x7EBF;&#x52A0;&#x5BC6;&#x7B97;&#x6CD5;&#x3002;</p
               'container': 'main', //element to find all selectors in
               'smoothScrolling': true, //enable or disable smooth scrolling on click
               'prefix': 'toc', //prefix for anchor tags and class names
-              'onHighlight': function(el) {}, //called when a new section is highlighted 
+              'onHighlight': function(el) {}, //called when a new section is highlighted
               'highlightOnScroll': true, //add class to heading that is currently in focus
               'highlightOffset': 100, //offset to trigger the next headline
               'anchorName': function(i, heading, prefix) { //custom function for anchor name
@@ -649,9 +651,9 @@ SM2-3&#x692D;&#x5706;&#x66F2;&#x7EBF;&#x52A0;&#x5BC6;&#x7B97;&#x6CD5;&#x3002;</p
             return $heading[0].tagName.toLowerCase();
           }
           });
-          
+
       </script>
-    
+
     <script>
       //TOC toggle animation
     $('#toggle').on('click', function(){
@@ -668,11 +670,11 @@ SM2-3&#x692D;&#x5706;&#x66F2;&#x7EBF;&#x52A0;&#x5BC6;&#x7B97;&#x6CD5;&#x3002;</p
         }
     });
     </script>
-    
+
     <script>
         // Scroll to top button
         window.onscroll = function() {scrollFunction()};
-        
+
         function scrollFunction() {
             if (document.body.scrollTop > 100 || document.documentElement.scrollTop > 100) {
                 document.getElementById("myBtn").style.display = "block";
@@ -680,14 +682,14 @@ SM2-3&#x692D;&#x5706;&#x66F2;&#x7EBF;&#x52A0;&#x5BC6;&#x7B97;&#x6CD5;&#x3002;</p
                 document.getElementById("myBtn").style.display = "none";
             }
         }
-        
+
         // When the user clicks on the button, scroll to the top of the document
         function topFunction() {
             document.body.scrollTop = 0;
             document.documentElement.scrollTop = 0;
         }
         </script>
-    
+
       <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
         asciimath2jax: {
@@ -695,7 +697,7 @@ SM2-3&#x692D;&#x5706;&#x66F2;&#x7EBF;&#x52A0;&#x5BC6;&#x7B97;&#x6CD5;&#x3002;</p
         }
      });
     </script>
-    
+
     <script>
       $(document).ready(function() {
         $('[id^=toc]').each(function ()

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
     0 CSS RESET
 */
 
-/* http://meyerweb.com/eric/tools/css/reset/ 
+/* http://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126
    License: none (public domain)
 */
@@ -16,8 +16,8 @@ b, u, i, center,
 dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
 	margin: 0;
@@ -28,7 +28,7 @@ time, mark, audio, video {
 	vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
+article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }
@@ -62,7 +62,7 @@ table {
       overflow: auto;
       padding: 0 0 0 45px;
       /*margin-right: 30px;*/
-      background-color:#f7f7f7; 
+      background-color:#f7f7f7;
   }
 
   #toggle {
@@ -78,10 +78,10 @@ table {
   #toggle span {
       text-align: center;
       width: 100%;
-      position: absolute;             
+      position: absolute;
       top: 50%;
       transform: translate(0, -50%);
-      
+
   }
 
 
@@ -172,8 +172,8 @@ span[id^="toc"]:after {
   padding-right: 6px;
   padding-top:4px;
   margin-left: -20px;
-  font-family: "Font Awesome 5 Free"; 
-  font-weight: 900; 
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
   font-size: 0.8em;
   color: #cfcfcf;
   content: "\f0c1";
@@ -340,12 +340,12 @@ p.document-stage {
 /*
     1 General Styles
 */
- 
+
   body {
     font-size: 1em;
     margin: 0;
      }
-  
+
 h1, h2, h3, h4, h5, h6 {
   margin-top: 1.5em;
   margin-bottom: 0.3em;
@@ -355,13 +355,13 @@ h1, h2, h3, h4, h5, h6 {
 
   h1 {
     font-size: 1.5em;
-    font-weight: 400; 
+    font-weight: 400;
   }
-  
+
   h2 {
     font-size: 1.3em;
     font-weight: 300; }
-  
+
   h3 {
     font-size: 1.1em;
     font-weight: 300; }
@@ -381,47 +381,53 @@ p {
   background-color: #f1f1f1;
   margin: 1em 0 1em 0;
 }
-  
+
   .WordSection2, .WordSection3 {
     margin: 0 1.5em; }
-  
+
   .zzSTDTitle1, .MsoCommentText {
     display: none; }
-  
+
   a:visited {
     text-decoration: none; }
-  
-  
+
+
   p.TermNum {
-    font-weight: 600;
+/*    font-weight: 600;*/
+    font-size: 1.3em;
+    font-weight: 300;
+    font-family: "SimSei", sans-serif;
     margin: 1em 0 0 0; }
-  
+
   p.Terms {
-    font-weight: 600;
+/*    font-weight: 600;*/
+    font-size: 1.3em;
+    font-weight: 300;
+    font-family: "SimSei", sans-serif;
     margin: 0 0 1em 0; }
-  
+
   p.AltTerms {
     font-weight: 400;
     font-style: italic;
     margin: 0; }
-  
+
   p.DeprecatedTerms {
     font-weight: 400;
     font-style: italic;
     margin: 0; }
-  
+
   ul {
     padding-left: 1em; }
-  
+
   #toc-list ul {
     margin-bottom: 0.25em; }
-  
+
   #toc-list li {
     list-style-type: none; }
-  
+
 .coverpage {
   text-align: center;
-  padding: 3em; 
+  padding: 3em;
 }
 
 .coverpage-category {
@@ -437,10 +443,10 @@ span.category-1 {
 }
 
 span.category-2 {
-  margin-left: 4em;
+  /*margin-left: 4em;*/
   display: block;
 }
-  
+
 .coverpage-logo {
   text-align: right;
   display: block;
@@ -448,13 +454,13 @@ span.category-2 {
 
 .coverpage-logo-gb-img {
   right:0;
-  margin-right: 4em;
+  /*margin-right: 4em;*/
 }
 
 .coverpage-logo-gb-img img {
   margin-top: 2em;
 }
-  
+
 span.coverpage-logo-text {
   font-size: 2.5em;
   right:0;
@@ -516,6 +522,7 @@ span.date-active {
 
 .coverpage_footer {
   text-align:center;
+
   width:100%;
 }
 
@@ -524,50 +531,50 @@ span.date-active {
     font-size: 1.2em;
     line-height: 1.2em;
     margin: 0.25em 0; }
-  
 
-  
+
+
   .coverpage-title {
     font-weight: 400; }
-  
+
   .coverpage-title .title-second {
     display: none; }
-  
+
   .coverpage-stage-block {
     font-style: italic;
     font-size: 1.25em;
     font-weight: 600; }
-  
+
   .coverpage-warning {
     border-top: solid 1px #f36f36;
     border-bottom: solid 1px #f36f36;
     margin: 1em 2em;
     color: #485094;
     padding: 1em; }
-  
+
   .coverpage-warning .title {
     color: #f36f36;
     font-weight: 500; }
-  
+
   .coverpage-warning .content {
     font-style: italic; }
-  
+
   .copyright {
     padding: 1em; }
-  
+
   .copyright .name {
     color: #485094;
     font-weight: 600; }
-  
+
   .copyright .address {
     color: #485094; }
-  
+
   div.rule {
     width: 100%;
     height: 1px;
     background-color: #485094;
     margin: 2em 0; }
-  
+
   p.MsoCommentText, li.MsoCommentText, div.MsoCommentText {
     margin-top: 0cm;
     margin-right: 0cm;
@@ -578,7 +585,7 @@ span.date-active {
     tab-stops: 20.15pt;
     font-size: 12.0pt;
     font-family: "SimSun", serif; }
-  
+
   p.MsoCommentSubject, li.MsoCommentSubject, div.MsoCommentSubject {
     margin-top: 0cm;
     margin-right: 0cm;
@@ -756,7 +763,7 @@ a.footnote-number {
 }
 
 
- 
+
 /* Printing styling
 
   p.Sourcecode, li.Sourcecode, div.Sourcecode, pre.Sourcecode {
@@ -769,7 +776,7 @@ a.footnote-number {
     tab-stops: 20.15pt;
     font-size: 9.0pt;
     font-family: "Courier New", monospace; }
-  
+
   p.Biblio, li.Biblio, div.Biblio {
     margin-top: 0cm;
     margin-right: 0cm;
@@ -780,7 +787,7 @@ a.footnote-number {
     line-height: 12.0pt;
     font-size: 11.0pt;
     font-family: "SimSun", serif; }
-  
+
   p.FigureTitle {
     margin-top: 0cm;
     margin-right: 0cm;
@@ -792,7 +799,7 @@ a.footnote-number {
     tab-stops: 20.15pt;
     font-size: 11.0pt;
     font-family: "SimSun", serif; }
-  
+
   p.TableTitle {
     margin-top: 0cm;
     margin-right: 0cm;
@@ -804,7 +811,7 @@ a.footnote-number {
     tab-stops: 20.15pt;
     font-size: 11.0pt;
     font-family: "SimSun", serif; }
-  
+
   p.Note, div.Note, li.Note {
     margin-top: 0in;
     margin-right: 0in;
@@ -817,7 +824,7 @@ a.footnote-number {
     font-size: 9.0pt;
     text-autospace: none;
     font-family: "SimSun", serif; }
-  
+
   p.ANNEX, li.ANNEX, div.ANNEX {
     margin-top: 0cm;
     margin-right: 0cm;
@@ -832,7 +839,7 @@ a.footnote-number {
     font-size: 14.0pt;
     font-family: "SimHei", sans-serif;
     font-weight: bold; }
-  
+
   p.BiblioTitle, li.BiblioTitle, div.BiblioTitle {
     margin-top: 0cm;
     margin-right: 0cm;
@@ -844,7 +851,7 @@ a.footnote-number {
     font-size: 14.0pt;
     font-family: "SimHei", sans-serif;
     font-weight: bold; }
-  
+
   p.Definition, li.Definition, div.Definition {
     margin-top: 0cm;
     margin-right: 0cm;
@@ -855,7 +862,7 @@ a.footnote-number {
     tab-stops: 20.15pt;
     font-size: 11.0pt;
     font-family: "SimSun", serif; }
-  
+
   p.ForewordTitle, li.ForewordTitle, div.ForewordTitle, h1.ForewordTitle {
     margin-top: 32.0pt;
     margin-right: 0cm;
@@ -868,7 +875,7 @@ a.footnote-number {
     tab-stops: 20.15pt;
     font-size: 16.0pt;
     font-family: "SimHei", sans-serif; }
-  
+
   p.IntroTitle, li.IntroTitle, div.IntroTitle, h1.IntroTitle {
     margin-top: 32.0pt;
     margin-right: 0cm;
@@ -881,7 +888,7 @@ a.footnote-number {
     tab-stops: 20.15pt;
     font-size: 16.0pt;
     font-family: "SimHei", sans-serif; }
-  
+
   p.zzContents, li.zzContents, div.zzContents {
     margin-top: 48.0pt;
     margin-right: 0cm;
@@ -894,7 +901,7 @@ a.footnote-number {
     tab-stops: 20.15pt;
     font-size: 16.0pt;
     font-family: "SimHei", sans-serif; }
-  
+
   p.zzCopyright, li.zzCopyright {
     margin-top: 0cm;
     margin-right: 14.2pt;
@@ -906,13 +913,13 @@ a.footnote-number {
     padding: 0cm;
     font-size: 11.0pt;
     font-family: "SimSun", serif; }
-  
+
   div.zzCopyright {
     border: solid windowtext 1.0pt;
     padding: 1.0pt 4.0pt 0cm 4.0pt;
     margin-left: 5.1pt;
     margin-right: 5.1pt; }
-  
+
   p.zzCopyright_address {
     margin-top: 0cm;
     margin-right: 14.2pt;
@@ -922,7 +929,7 @@ a.footnote-number {
     padding-left: 20pt;
     font-size: 10.0pt;
     text-align: left; }
-  
+
   p.zzSTDTitle, li.zzSTDTitle, div.zzSTDTitle {
     margin-top: 20.0pt;
     margin-right: 0cm;
@@ -933,7 +940,7 @@ a.footnote-number {
     tab-stops: 20.15pt;
     font-size: 16.0pt;
     font-family: "SimHei", sans-serif; }
-  
+
   p.zzSTDTitle1, li.zzSTDTitle1, div.zzSTDTitle1 {
     margin-top: 0pt;
     margin-right: 0cm;
@@ -944,7 +951,7 @@ a.footnote-number {
     tab-stops: 20.15pt;
     font-size: 16.0pt;
     font-family: "SimHei", sans-serif; }
-  
+
   p.Quote, li.Quote, div.Quote {
     margin-top: 0cm;
     margin-right: 36.0pt;
@@ -955,10 +962,10 @@ a.footnote-number {
     tab-stops: 20.15pt;
     font-size: 11.0pt;
     font-family: "SimSun", serif; }
-  
+
   p.QuoteAttribution {
     text-align: right; }
-  
+
   p.Admonition, li.Admonition, div.Admonition {
     margin-top: 0cm;
     margin-right: 57.6pt;
@@ -971,7 +978,7 @@ a.footnote-number {
     font-family: "SimSun", serif;
     color: #4472C4;
     font-style: italic; }
-  
+
   p.Code, li.Code, div.Code {
     margin: 0cm;
     margin-bottom: .0001pt;
@@ -979,7 +986,7 @@ a.footnote-number {
     tab-stops: 20.15pt;
     font-size: 9.0pt;
     font-family: "Courier New", monospace; }
-  
+
   p.Formula, li.Formula, div.Formula {
     margin-top: 0cm;
     margin-right: 0cm;
@@ -989,7 +996,7 @@ a.footnote-number {
     tab-stops: right 487.45pt;
     font-size: 11.0pt;
     font-family: "SimSun", serif; }
-  
+
   .h2Annex {
     margin-top: 7.8pt;
     margin-right: 0cm;
@@ -1001,116 +1008,116 @@ a.footnote-number {
     tab-stops: 27.0pt 35.0pt;
     font-size: 10.5pt;
     font-family: "SimHei", sans-serif; }
-  
+
   @page WordSection1 {
     size: 595.3pt 841.9pt;
     margin: 39.7pt 53.85pt 1.0cm 53.85pt; }
   div.WordSection1 {
     page: WordSection1; }
-  
+
   @page WordSection2 {
     size: 595.3pt 841.9pt;
     margin: 1.0in 1.25in 1.0in 1.25in; }
   div.WordSection2 {
     page: WordSection2; }
-  
+
   @page WordSection3 {
     size: 595.3pt 841.9pt;
     margin: 1.0in 1.25in 1.0in 1.25in; }
   div.WordSection3 {
     page: WordSection3; }
-  
+
   ol {
     margin-bottom: 0cm; }
-  
+
   ul {
     margin-bottom: 0cm; }
-  
+
   table.MsoISOTable {
     border-collapse: collapse;
     border: solid windowtext 2pt;
     font-size: 10.0pt;
     font-family: "SimSun", serif; }
-  
+
   table.MsoISOTable tr {
     page-break-inside: avoid; }
-  
+
   table.MsoISOTable th {
     border: solid windowtext 1pt;
     padding: 0cm 2.85pt 0cm 2.85pt; }
-  
+
   table.MsoISOTable td {
     border: solid windowtext 1pt;
     padding: 0cm 2.85pt 0cm 2.85pt; }
-  
+
   table.MsoTableGrid {
     border: solid windowtext 1.0pt;
     font-size: 10.0pt;
     font-family: "SimSun", serif; }
-  
+
   td {
     page-break-inside: avoid; }
-  
+
   tr {
     page-break-after: avoid; }
-  
+
   span.stem {
     font-family: "Cambria Math",serif;
     font-style: italic; }
-  
+
   div.formula {
     tab-stops: right 487.45pt; }
-  
+
   body {
     tab-interval: 21.0pt;
     text-justify-trim: punctuation; }
-  
+
   dt {
     page-break-inside: avoid;
     page-break-after: avoid; }
-  
+
   .coverpage_docnumber {
     text-align: center;
     font-size: 14.0pt;
     font-weight: bold; }
-  
+
   .coverpage_techcommittee {
     text-align: center; }
-  
+
   .coverpage_docstage {
     text-align: center;
     font-size: 30.0pt;
     color: #485094; }
-  
+
   div.coverpage_warning {
     border: solid windowtext 1.0pt #485094;
     padding: 1.0pt 4.0pt 1.0pt 4.0pt #485094;
     margin-left: 4.25pt;
     margin-right: 4.25pt; }
-  
+
   .coverpage_warning {
     color: #485094;
     font-size: 10.0pt; }
-  
+
   .coverpage_footer {
     text-align: center;
     font-family: "SimHei", sans-serif; }
-  
+
   .coverpage_footer table {
     text-align: left;
     margin-left: auto;
     margin-right: auto; }
-  
+
   a.TableFootnoteRef {
     vertical-align: super; }
-  
+
   aside {
     font-size: 10.0pt; }
-  
+
   .Hant {
     font-family: PMingLiU; }
-  
- 
+
+
   p.example, li.example, div.example {
 
     margin: 0in;
@@ -1120,7 +1127,7 @@ a.footnote-number {
     text-indent: 18.15pt;
     font-size: 9.0pt;
     font-family: "SimSun", serif; }
-  
+
   p.leftpagenumber, li.leftpagenumber, div.leftpagenumber {
     margin-top: 6.0pt;
     margin-right: 0cm;
@@ -1129,7 +1136,7 @@ a.footnote-number {
     margin-bottom: .0001pt;
     font-size: 9.0pt;
     font-family: "SimSun", serif; }
-  
+
   p.rightpagenumber, li.rightpagenumber, div.rightpagenumber {
     margin-top: 6.0pt;
     margin-right: 0cm;
@@ -1139,7 +1146,7 @@ a.footnote-number {
     text-align: right;
     font-size: 9.0pt;
     font-family: "SimSun", serif; }
-  
+
   p.supersedes, li.supersedes, div.supersedes {
 
     margin-top: 2.85pt;
@@ -1151,7 +1158,7 @@ a.footnote-number {
     line-height: 14.0pt;
     font-size: 10.5pt;
     font-family: "SimSun", serif; }
-  
+
   table.dl {
     margin-top: 0cm;
     margin-right: 0cm;


### PR DESCRIPTION
Fixes:

* Cover page styling:
  * logo should fully align to right
  * "ICS" code should fully align to left
* "IS Stage" should not be shown on cover page - only draft stages will have text. I've removed it here for now. And we should style that as well (@opoudjis could you help provide extra html?)
* "Terms" section HTML is not compliant -- we need to change them to actual sections instead of thing like `<p class=TermNum>`. They should be tagged and styled just like normal sections.
